### PR TITLE
Require cvmfs >= 2.6.0, update to version 2.1-2

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -8,5 +8,5 @@ Homepage: http://cernvm.cern.ch/portal/filesystem
 
 Package: cvmfs-x509-helper
 Architecture: i386 amd64
-Depends: ${shlibs:Depends}, cvmfs, libglobus-common0, libglobus-gsi-callback0, libglobus-gsi-cert-utils0, libglobus-gsi-credential1, libvomsapi1 | libvomsapi1v5
+Depends: ${shlibs:Depends}, cvmfs (>= 2.6.0), libglobus-common0, libglobus-gsi-callback0, libglobus-gsi-cert-utils0, libglobus-gsi-credential1, libvomsapi1 | libvomsapi1v5
 Description: CernVM File System X509 authz helper

--- a/packaging/debian/cvmfs-x509-helper.dsc
+++ b/packaging/debian/cvmfs-x509-helper.dsc
@@ -1,7 +1,7 @@
 # created by ../../ci/obsupdate-deb.sh, do not edit by hand
 Debtransform-Tar: cvmfs-x509-helper-2.1.tar.gz
 Format: 1.0
-Version: 2.1.1-1
+Version: 2.1.2-1
 Binary: cvmfs-x509-helper
 Source: cvmfs-x509-helper
 Maintainer: Jakob Blomer <jblomer@cern.ch>
@@ -13,7 +13,7 @@ Homepage: http://cernvm.cern.ch/portal/filesystem
 
 Package: cvmfs-x509-helper
 Architecture: i386 amd64
-Depends: ${shlibs:Depends}, cvmfs, libglobus-common0, libglobus-gsi-callback0, libglobus-gsi-cert-utils0, libglobus-gsi-credential1, libvomsapi1 | libvomsapi1v5
+Depends: ${shlibs:Depends}, cvmfs (>= 2.6.0), libglobus-common0, libglobus-gsi-callback0, libglobus-gsi-cert-utils0, libglobus-gsi-credential1, libvomsapi1 | libvomsapi1v5
 Description: CernVM File System X509 authz helper
 Files:
   ffffffffffffffffffffffffffffffff 99999 file1

--- a/packaging/rpm/cvmfs-x509-helper.spec
+++ b/packaging/rpm/cvmfs-x509-helper.spec
@@ -4,7 +4,7 @@ Summary: CernVM File System Authz Helper
 Name: cvmfs-x509-helper
 Version: 2.1
 # The release_prefix macro is used in the OBS prjconf, don't change its name
-%define release_prefix 1
+%define release_prefix 2
 Release: %{release_prefix}%{?dist}
 Source0: https://ecsft.cern.ch/dist/cvmfs/%{name}-%{version}.tar.gz
 Group: Applications/System
@@ -31,7 +31,7 @@ BuildRequires: pkgconfig
 BuildRequires: voms-devel
 BuildRequires: scitokens-cpp-devel
 
-Requires: cvmfs
+Requires: cvmfs >= 2.6.0
 
 %description
 Authorization helper to verify X.509 proxy certificates, VOMS membership, and scitokens for
@@ -74,6 +74,9 @@ rm -rf $RPM_BUILD_ROOT
 %doc COPYING AUTHORS README ChangeLog
 
 %changelog
+* Thu Sep 19 2019 Dave Dykstra <dwd@fnal.gov> - 2.1-2
+- Change cvmfs requirement to >= 2.6.0 for SciTokens support
+
 * Thu Sep 12 2019 Dave Dykstra <dwd@fnal.gov> - 2.1-1
 - Fix bug preventing from running unprivileged
 


### PR DESCRIPTION
This merges in a change made by OSG in version 2.0-3, to require cvmfs >= 2.6.0 for SciTokens support.