### PR TITLE
Continue instead of exiting after scitoken success

### DIFF
--- a/src/x509_helper.cc
+++ b/src/x509_helper.cc
@@ -217,7 +217,7 @@ int main(int argc, char **argv) {
         if (validation_status == kCheckTokenGood) {
           WriteMsg("{\"cvmfs_authz_v1\":{\"msgid\":3,\"revision\":0,"
                     "\"status\":0,\"bearer_token\":\"" + proxy + "\"}}");
-          return 0;
+          continue;
         }
       }
       


### PR DESCRIPTION
Currently the scitoken helper exits immediately after the first successful authentication with a token.  This prevents it from exiting.