### PR TITLE
Add debug logging of authorization subject

### DIFF
--- a/src/helper_utils.cc
+++ b/src/helper_utils.cc
@@ -96,7 +96,7 @@ FILE *GetFile(const std::string &env_name, pid_t pid, uid_t uid, gid_t gid, cons
     }
 
   }
-  LogAuthz(kLogAuthzDebug, "looking for proxy in file %s", path);
+  LogAuthz(kLogAuthzDebug, "looking for authorization in file %s", path);
 
   /**
    * If the target process is running inside a container, then we must

--- a/src/scitoken_helper_check.h
+++ b/src/scitoken_helper_check.h
@@ -14,11 +14,11 @@ enum StatusSciTokenValidation {
 };
 
 typedef StatusSciTokenValidation (*CheckSciToken_t)(const char* membership,
-                                                    FILE *fp_token);
+                                       FILE *fp_token, FILE *fp_debug);
 
 extern "C" {
 StatusSciTokenValidation CheckSciToken(const char* membership,
-                                       FILE *fp_token);
+                                       FILE *fp_token, FILE *fp_debug);
 }
 
 #endif  // CVMFS_AUTHZ_SCITOKEN_HELPER_CHECK_H_

--- a/src/x509_helper.cc
+++ b/src/x509_helper.cc
@@ -190,6 +190,7 @@ int main(int argc, char **argv) {
   }
   LogAuthz(kLogAuthzDebug, "Executable: %s", basename(argv[0]));
 
+  FILE *fp_debug = GetLogAuthzDebugFile();
   while (true) {
     msg = ReadMsg();
     LogAuthz(kLogAuthzDebug, "got authz request %s", msg.c_str());
@@ -211,7 +212,7 @@ int main(int argc, char **argv) {
       if (fp_token) {
         LogAuthz(kLogAuthzDebug, "Calling SciTokens checker");
         StatusSciTokenValidation validation_status =
-          (*checker)(request.membership.c_str(), fp_token);
+          (*checker)(request.membership.c_str(), fp_token, fp_debug);
         LogAuthz(kLogAuthzDebug, "validation status is %d", validation_status);
 
         if (validation_status == kCheckTokenGood) {

--- a/src/x509_helper_check.cc
+++ b/src/x509_helper_check.cc
@@ -333,6 +333,7 @@ StatusX509Validation CheckX509Proxy(const string &membership, FILE *fp_proxy) {
   authz_data *voms_data = GenerateVOMSData(fp_proxy);
   if (voms_data == NULL)
     return kCheckX509Invalid;
+  LogAuthz(kLogAuthzDebug, "Checking proxy subject %s", voms_data->dn_);
   const bool result = CheckMultipleAuthz(voms_data, membership);
   delete voms_data;
   return result ? kCheckX509Good : kCheckX509NotMember;

--- a/src/x509_helper_log.cc
+++ b/src/x509_helper_log.cc
@@ -40,6 +40,13 @@ void SetLogAuthzDebug(const string &path) {
   assert(file_debug != NULL);
 }
 
+FILE *GetLogAuthzDebugFile() {
+  return file_debug;
+}
+
+void SetLogAuthzDebugFile(FILE *fd) {
+  file_debug = fd;
+}
 
 void SetLogAuthzSyslogLevel(const int level) {
   switch (level) {

--- a/src/x509_helper_log.h
+++ b/src/x509_helper_log.h
@@ -17,5 +17,7 @@ void SetLogAuthzSyslogLevel(const int level);
 void SetLogAuthzSyslogFacility(const int local_facility);
 void SetLogAuthzSyslogPrefix(const std::string &prefix);
 void LogAuthz(const int flags, const char *format, ...);
+FILE *GetLogAuthzDebugFile();
+void SetLogAuthzDebugFile(FILE *fd);
 
 #endif  // CVMFS_AUTHZ_X509_HELPER_LOG_H_


### PR DESCRIPTION
This adds debug logging of x.509 proxy subjects and json web token sub claims.  Debug logging for the scitokens helper wasn't working at all, and this fixes that.

Fixes #28.