### PR TITLE
Implement WLCG bearer token discovery

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set (CVMFS_X509_HELPER_SOURCES
 
 set (LIBCVMFS_X509_HELPER_SOURCES
   scitoken_helper_check.cc scitoken_helper_check.h
+  helper_utils.cc helper_utils.h
   x509_helper_log.cc x509_helper_log.h)
 
 set (CVMFS_X509_VALIDATOR_SOURCES

--- a/src/helper_utils.h
+++ b/src/helper_utils.h
@@ -11,6 +11,8 @@
 
 
 FILE *GetFile(const std::string &env_name, const pid_t pid, const uid_t uid, const gid_t gid, const std::string &default_path);
+FILE *GetEnvVarFile(const std::string &env_name, const pid_t pid);
+void GetStringFromFile(FILE *fp, std::string &str);
 
 #endif // CVMFS_AUTHZ_HELPER_UTILS_H_
 

--- a/src/scitoken_helper_check.cc
+++ b/src/scitoken_helper_check.cc
@@ -17,6 +17,8 @@
 #include <memory>
 #include <unistd.h>
 
+#include "helper_utils.h"
+
 using namespace std;  // NOLINT
 
 
@@ -29,22 +31,9 @@ StatusSciTokenValidation CheckSciToken(const char* membership, FILE *fp_token, F
 
   // Read in the entire scitoken into memory
   string token;
-  const unsigned int N=1024;
-  while (true) {
-    char buf[N];
-    size_t read = fread((void *)&buf[0], 1, N, fp_token);
-    if (ferror(fp_token)) {
-      LogAuthz(kLogAuthzDebug, "Error reading token file");
-      return kCheckTokenInvalid;
-    }
-    if (read) { token.append(string(buf, read)); }
-    if (read < N) { break; }
-    // If the token is larger than 1MB, then stop reading in the token
-    // Possible malicious user
-    if ( token.size() > (1024 * 1024) ) {
-      LogAuthz(kLogAuthzDebug, "SciToken larger than 1 MB");
-      return kCheckTokenInvalid;
-    }
+  GetStringFromFile(fp_token, token);
+  if (token == "") {
+    return kCheckTokenInvalid;
   }
 
   // Loop through the membership, looking for "https://" issuers

--- a/src/x509_helper.cc
+++ b/src/x509_helper.cc
@@ -205,7 +205,7 @@ int main(int argc, char **argv) {
       if (getenv("CVMFS_TOKEN_VARNAME")) {
         var_name = getenv("CVMFS_TOKEN_VARNAME");
       } else {
-        var_name = "TOKEN";
+        var_name = "BEARER_TOKEN_FILE";
       }
       FILE *fp_token = GetSciToken(request, &proxy, var_name);
       // This will close fp_proxy along the way.

--- a/src/x509_helper.cc
+++ b/src/x509_helper.cc
@@ -214,6 +214,7 @@ int main(int argc, char **argv) {
         StatusSciTokenValidation validation_status =
           (*checker)(request.membership.c_str(), fp_token, fp_debug);
         LogAuthz(kLogAuthzDebug, "validation status is %d", validation_status);
+        fclose(fp_token);
 
         if (validation_status == kCheckTokenGood) {
           WriteMsg("{\"cvmfs_authz_v1\":{\"msgid\":3,\"revision\":0,"


### PR DESCRIPTION
This implements WLCG bearer token discovery.  The default variable name if CVMFS_TOKEN_VARNAME is not set is changed from TOKEN to BEARER_TOKEN_FILE.  If it is set to something else, then that part doesn't follow WLCG bearer token discovery rules.  Debug log messaging is improved to show what environment variable a token or proxy is coming from.

It also fixes the fact that the scitoken helper was not closing the file descriptor to the token file.

Fixes #24