### PR TITLE
x509_helper_log.cc: add "#include <ctime>"

### DIFF
--- a/src/x509_helper_log.cc
+++ b/src/x509_helper_log.cc
@@ -14,6 +14,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <ctime>
 
 using namespace std;  // NOLINT
 


### PR DESCRIPTION
This allows the software to build under Debian 12 Bookworm (with gcc 12.2.0) - closes #35 